### PR TITLE
JavaD tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ record/localstore
 config/credentials.config
 out
 target
+*.iml

--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@
 
 ## 2. How to start
 
-- Open `src/main/java/befaster/Start.java`
+- Open `src/main/java/befaster/SendCommandToServer.java`
 - Read the comments as documentation, they will guide through the rest of the setup

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 
 apply plugin: 'application'
 
-mainClassName = 'befaster.ConnectToServer'
+mainClassName = 'befaster.SendCommandToServer'
 
 run {
     standardInput = System.in

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 
 apply plugin: 'application'
 
-mainClassName = 'befaster.Start'
+mainClassName = 'befaster.ConnectToServer'
 
 run {
     standardInput = System.in

--- a/src/main/java/befaster/ConnectToServer.java
+++ b/src/main/java/befaster/ConnectToServer.java
@@ -11,7 +11,7 @@ import befaster.solutions.Sum;
 import static befaster.runner.CredentialsConfigFile.readFromConfigFile;
 import static befaster.runner.TypeConversion.asInt;
 
-public class Start {
+public class ConnectToServer {
     /**
      * ~~~~~~~~~~ Running the system: ~~~~~~~~~~~~~
      *
@@ -44,7 +44,7 @@ public class Start {
      *   |      |   ./src/main/java/befaster/solutions    |                                               |
      *   |  5.  | Run "testConnectivity", observe output  |                                               |
      *   |  6.  | If ready, run "deployToProduction"      |                                               |
-     *   |  7.  |                                         | Type "done"                                   |
+     *   |  7.  |                                         | Type "deploy"                                 |
      *   |  8.  |                                         | Check failed requests                         |
      *   |  9.  |                                         | Go to step 2.                                 |
      *   +------+-----------------------------------------+-----------------------------------------------+
@@ -53,7 +53,7 @@ public class Start {
     public static void main(String[] args) throws ConfigNotFoundException {
 
         ClientRunner.forUsername(readFromConfigFile("tdl_username"))
-                .withServerHostname("run.befaster.io")
+                .withServerHostname("localhost")
                 .withActionIfNoArgs(RunnerAction.testConnectivity)
                 .withSolutionFor("sum", p -> Sum.sum(asInt(p[0]), asInt(p[1])))
                 .withSolutionFor("hello", p -> Hello.hello(p[0]))

--- a/src/main/java/befaster/ConnectToServer.java
+++ b/src/main/java/befaster/ConnectToServer.java
@@ -53,7 +53,7 @@ public class ConnectToServer {
     public static void main(String[] args) throws ConfigNotFoundException {
 
         ClientRunner.forUsername(readFromConfigFile("tdl_username"))
-                .withServerHostname("localhost")
+                .withServerHostname("run.befaster.io")
                 .withActionIfNoArgs(RunnerAction.testConnectivity)
                 .withSolutionFor("sum", p -> Sum.sum(asInt(p[0]), asInt(p[1])))
                 .withSolutionFor("hello", p -> Hello.hello(p[0]))

--- a/src/main/java/befaster/SendCommandToServer.java
+++ b/src/main/java/befaster/SendCommandToServer.java
@@ -11,7 +11,7 @@ import befaster.solutions.Sum;
 import static befaster.runner.CredentialsConfigFile.readFromConfigFile;
 import static befaster.runner.TypeConversion.asInt;
 
-public class ConnectToServer {
+public class SendCommandToServer {
     /**
      * ~~~~~~~~~~ Running the system: ~~~~~~~~~~~~~
      *

--- a/src/main/java/befaster/runner/ChallengeServerClient.java
+++ b/src/main/java/befaster/runner/ChallengeServerClient.java
@@ -19,9 +19,6 @@ class ChallengeServerClient {
     private String acceptHeader;
 
     static final String DONE_ENDPOINT = "done";
-    static final String CONTINUE_ENDPOINT = "continue";
-    static final String PAUSE_ENDPOINT = "pause";
-    static final String START_ENDPOINT = "start";
     private static final String UTF_8 = "UTF-8";
     private static final String JOURNEY_PROGRESS_ENDPOINT = "journeyProgress";
     private static final String AVAILABLE_ACTIONS = "availableActions";

--- a/src/main/java/befaster/runner/ChallengeServerClient.java
+++ b/src/main/java/befaster/runner/ChallengeServerClient.java
@@ -28,10 +28,10 @@ class ChallengeServerClient {
     static final String ROUND_DESCRIPTION = "roundDescription";
 
 
-    ChallengeServerClient(String url, String base64JourneyId, boolean disableColours) {
+    ChallengeServerClient(String url, String base64JourneyId, boolean useColours) {
         this.url = url;
         this.base64JourneyId = base64JourneyId;
-        this.acceptHeader = disableColours ? "text/not-coloured" : "text/coloured";
+        this.acceptHeader = useColours ? "text/coloured" : "text/not-coloured";
     }
 
     String sendAction(String name) throws IOException, UnirestException, ClientErrorException, ServerErrorException, OtherServerException {
@@ -52,7 +52,7 @@ class ChallengeServerClient {
         } else if (isOtherErrorResponse(responseInt)) {
             throw new OtherServerException();
         }
-        return actionResponse.getBody().trim();
+        return actionResponse.getBody();
     }
 
     private boolean isOtherErrorResponse(int responseInt) {

--- a/src/main/java/befaster/runner/ChallengeServerClient.java
+++ b/src/main/java/befaster/runner/ChallengeServerClient.java
@@ -45,8 +45,9 @@ class ChallengeServerClient {
                 +actionResponse.getStatus()+" - " + actionResponse.getStatusText());
 
         int responseInt = actionResponse.getStatus();
+
         if (isClientError(responseInt)) {
-            throw new ClientErrorException();
+            throw new ClientErrorException(actionResponse.getBody());
         } else if (isServerError(responseInt)) {
             throw new ServerErrorException();
         } else if (isOtherErrorResponse(responseInt)) {
@@ -104,5 +105,14 @@ class ChallengeServerClient {
     }
 
     class ClientErrorException extends Exception {
+        String responseMessage;
+
+        ClientErrorException(String message) {
+            this.responseMessage = message;
+        }
+
+        public String getResponseMessage() {
+            return responseMessage;
+        }
     }
 }

--- a/src/main/java/befaster/runner/ChallengeServerClient.java
+++ b/src/main/java/befaster/runner/ChallengeServerClient.java
@@ -33,9 +33,9 @@ public class ChallengeServerClient {
         this.acceptHeader = disableColours ? "text/not-coloured" : "text/coloured";
     }
 
-    public String sendAction(String name) throws IOException, UnirestException, ClientErrorException, ServerErrorException, OtherServerException {
+    String sendAction(String name) throws IOException, UnirestException, ClientErrorException, ServerErrorException, OtherServerException {
         String encodedPath = URLEncoder.encode(this.base64JourneyId, "UTF8");
-        String url = String.format("http://%s:%d/action/%s", this.url, port, encodedPath);
+        String url = String.format("http://%s:%d/action/%s/%s", this.url, port, name, encodedPath);
         HttpResponse<String> actionResponse =  Unirest.post(url)
                 .header("accept", this.acceptHeader)
                 .header("charset", "UTF8")
@@ -74,7 +74,7 @@ public class ChallengeServerClient {
         return get(AVAILABLE_ACTIONS);
     }
 
-    String get(String name) throws UnsupportedEncodingException, UnirestException {
+    private String get(String name) throws UnsupportedEncodingException, UnirestException {
         String encodedPath = URLEncoder.encode(this.base64JourneyId, UTF_8);
         String url = String.format("http://%s:%d/%s/%s", this.url, port, name, encodedPath);
         return getStringResponse(url);

--- a/src/main/java/befaster/runner/ChallengeServerClient.java
+++ b/src/main/java/befaster/runner/ChallengeServerClient.java
@@ -23,9 +23,9 @@ class ChallengeServerClient {
     static final String PAUSE_ENDPOINT = "pause";
     static final String START_ENDPOINT = "start";
     private static final String UTF_8 = "UTF-8";
-    static final String JOURNEY_PROGRESS_ENDPOINT = "journeyProgress";
-    static final String AVAILABLE_ACTIONS = "availableActions";
-    static final String ROUND_DESCRIPTION = "roundDescription";
+    private static final String JOURNEY_PROGRESS_ENDPOINT = "journeyProgress";
+    private static final String AVAILABLE_ACTIONS = "availableActions";
+    private static final String ROUND_DESCRIPTION = "roundDescription";
 
 
     ChallengeServerClient(String url, String base64JourneyId, boolean useColours) {
@@ -95,7 +95,7 @@ class ChallengeServerClient {
         String responseString = response.getBody();
         LOG.debug("Response Status = " + response.getStatus());
         LOG.debug("Receives response: " + responseString);
-        return responseString.trim();
+        return responseString;
     }
 
     class ServerErrorException extends Exception {
@@ -111,7 +111,7 @@ class ChallengeServerClient {
             this.responseMessage = message;
         }
 
-        public String getResponseMessage() {
+        String getResponseMessage() {
             return responseMessage;
         }
     }

--- a/src/main/java/befaster/runner/ChallengeServerClient.java
+++ b/src/main/java/befaster/runner/ChallengeServerClient.java
@@ -11,20 +11,21 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 
 
-public class ChallengeServerClient {
+class ChallengeServerClient {
     private final Logger LOG = LoggerFactory.getLogger(ChallengeServerClient.class);
     private String url;
     private String base64JourneyId;
     private int port = 8222;
     private String acceptHeader;
 
-    public static final String DONE_ENDPOINT = "done";
-    public static final String CONTINUE_ENDPOINT = "continue";
-    public static final String PAUSE_ENDPOINT = "pause";
-    public static final String START_ENDPOINT = "start";
+    static final String DONE_ENDPOINT = "done";
+    static final String CONTINUE_ENDPOINT = "continue";
+    static final String PAUSE_ENDPOINT = "pause";
+    static final String START_ENDPOINT = "start";
     private static final String UTF_8 = "UTF-8";
     static final String JOURNEY_PROGRESS_ENDPOINT = "journeyProgress";
     static final String AVAILABLE_ACTIONS = "availableActions";
+    static final String ROUND_DESCRIPTION = "roundDescription";
 
 
     ChallengeServerClient(String url, String base64JourneyId, boolean disableColours) {
@@ -72,6 +73,10 @@ public class ChallengeServerClient {
 
     String getAvailableActions() throws UnsupportedEncodingException, UnirestException {
         return get(AVAILABLE_ACTIONS);
+    }
+
+    String getRoundDescription() throws UnsupportedEncodingException, UnirestException {
+        return get(ROUND_DESCRIPTION);
     }
 
     private String get(String name) throws UnsupportedEncodingException, UnirestException {

--- a/src/main/java/befaster/runner/ChallengeServerClient.java
+++ b/src/main/java/befaster/runner/ChallengeServerClient.java
@@ -18,7 +18,7 @@ class ChallengeServerClient {
     private int port = 8222;
     private String acceptHeader;
 
-    static final String DONE_ENDPOINT = "done";
+    static final String DEPLOY_ENDPOINT = "deploy";
     private static final String UTF_8 = "UTF-8";
     private static final String JOURNEY_PROGRESS_ENDPOINT = "journeyProgress";
     private static final String AVAILABLE_ACTIONS = "availableActions";

--- a/src/main/java/befaster/runner/ClientRunner.java
+++ b/src/main/java/befaster/runner/ClientRunner.java
@@ -76,12 +76,12 @@ public class ClientRunner {
                 System.out.println(response);
 
                 if (line.equals("start")) {
-                    readRunnerActionFromArgs(new String[]{"getNewRoundDescription"});
+                    readRunnerActionFrom("getNewRoundDescription");
                 } else if (line.equals("done")) {
-                    readRunnerActionFromArgs(new String[]{"deployToProduction"});
+                    readRunnerActionFrom("deployToProduction");
                 }
             } else {
-                readRunnerActionFromArgs(new String[]{line});
+                readRunnerActionFrom(line);
             }
         } catch (UnsupportedEncodingException e) {
             LOG.error("Could not encode the URL - badly formed URL?", e);
@@ -100,8 +100,17 @@ public class ClientRunner {
         }
     }
 
+    private void readRunnerActionFrom(String arg) {
+        RunnerAction runnerAction = extractActionFrom(arg).orElse(defaultRunnerAction);
+        readRunnerAction(runnerAction);
+    }
+
     private void readRunnerActionFromArgs(String[] args) {
         RunnerAction runnerAction = extractActionFrom(args).orElse(defaultRunnerAction);
+        readRunnerAction(runnerAction);
+    }
+
+    private void readRunnerAction(RunnerAction runnerAction) {
         System.out.println("Chosen action is: "+runnerAction.name());
 
         Client client = new Client.Builder()
@@ -138,6 +147,10 @@ public class ClientRunner {
 
     private static Optional<RunnerAction> extractActionFrom(String[] args) {
         String firstArg = args.length > 0 ? args[0] : null;
+        return extractActionFrom(firstArg);
+    }
+
+    private static Optional<RunnerAction> extractActionFrom(String firstArg) {
         return Arrays.stream(RunnerAction.values())
                 .filter(runnerAction -> runnerAction.name().equalsIgnoreCase(firstArg))
                 .findFirst();

--- a/src/main/java/befaster/runner/ClientRunner.java
+++ b/src/main/java/befaster/runner/ClientRunner.java
@@ -16,7 +16,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import static befaster.runner.ChallengeServerClient.DONE_ENDPOINT;
+import static befaster.runner.ChallengeServerClient.DEPLOY_ENDPOINT;
 import static befaster.runner.CredentialsConfigFile.readFromConfigFile;
 import static befaster.runner.RoundManagement.saveDescription;
 import static tdl.client.actions.ClientActions.publish;
@@ -133,7 +133,7 @@ public class ClientRunner {
             }
 
             String userInput = readUserInput();
-            if (userInput.equals(DONE_ENDPOINT)) {
+            if (userInput.equals(DEPLOY_ENDPOINT)) {
                 executeRunnerAction(RunnerAction.deployToProduction);
             }
 

--- a/src/main/java/befaster/runner/ClientRunner.java
+++ b/src/main/java/befaster/runner/ClientRunner.java
@@ -163,10 +163,8 @@ public class ClientRunner {
 
 
     private boolean isRecordingSystemOk() {
-        boolean requireRecording = Boolean.parseBoolean(readFromConfigFile("tdl_require_rec", "true"));
-
         //noinspection SimplifiableIfStatement
-        if (requireRecording) {
+        if (RecordingSystem.isRecordingRequired()) {
             return RecordingSystem.isRunning();
         } else {
             return true;

--- a/src/main/java/befaster/runner/ClientRunner.java
+++ b/src/main/java/befaster/runner/ClientRunner.java
@@ -72,13 +72,15 @@ public class ClientRunner {
 
             //check if server or runner action.
             if (isServerAction(line)) {
+                if (line.equals("done")) {
+                    readRunnerActionFrom("deployToProduction");
+                }
+
                 String response = challengeServerClient.sendAction(line);
                 System.out.println(response);
 
                 if (line.equals("start")) {
                     readRunnerActionFrom("getNewRoundDescription");
-                } else if (line.equals("done")) {
-                    readRunnerActionFrom("deployToProduction");
                 }
             } else {
                 readRunnerActionFrom(line);

--- a/src/main/java/befaster/runner/ClientRunner.java
+++ b/src/main/java/befaster/runner/ClientRunner.java
@@ -13,6 +13,7 @@ import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.util.*;
 
+import static befaster.runner.ChallengeServerClient.CONTINUE_ENDPOINT;
 import static befaster.runner.ChallengeServerClient.DONE_ENDPOINT;
 import static befaster.runner.ChallengeServerClient.START_ENDPOINT;
 import static befaster.runner.CredentialsConfigFile.readFromConfigFile;
@@ -117,7 +118,7 @@ public class ClientRunner {
         String response = challengeServerClient.sendAction(line);
         System.out.println(response);
 
-        if (line.equals(START_ENDPOINT) || line.equals(DONE_ENDPOINT)) {
+        if (line.equals(START_ENDPOINT) || line.equals(DONE_ENDPOINT) || line.equals(CONTINUE_ENDPOINT)) {
             String responseString = challengeServerClient.getRoundDescription();
             parseDescriptionFromResponse(responseString);
         }

--- a/src/main/java/befaster/runner/ClientRunner.java
+++ b/src/main/java/befaster/runner/ClientRunner.java
@@ -76,7 +76,11 @@ public class ClientRunner {
         boolean continueLoop = true;
         do {
             try {
-                showProgressAndAvailableActions(challengeServerClient);
+                System.out.println(challengeServerClient.getJourneyProgress());
+                boolean hasActions = hasAvailableActionsAndPrint(challengeServerClient);
+                if (!hasActions) {
+                    break;
+                }
                 BufferedReader buffer = new BufferedReader(new InputStreamReader(System.in));
                 String line = buffer.readLine().trim();
 
@@ -97,6 +101,12 @@ public class ClientRunner {
                 System.out.println(e.getResponseMessage());
             }
         } while (continueLoop);
+    }
+
+    private boolean hasAvailableActionsAndPrint(ChallengeServerClient challengeServerClient) throws UnsupportedEncodingException, UnirestException {
+        String availableActions = challengeServerClient.getAvailableActions();
+        System.out.println(availableActions);
+        return !availableActions.contains("No actions available.");
     }
 
     private void readAndExecuteAction(String line, ChallengeServerClient challengeServerClient) throws IOException, UnirestException, ChallengeServerClient.ServerErrorException, ChallengeServerClient.ClientErrorException, ChallengeServerClient.OtherServerException {
@@ -154,11 +164,6 @@ public class ClientRunner {
         String journeyId = readFromConfigFile("tdl_journey_id");
         boolean useColours = Boolean.parseBoolean(readFromConfigFile("tdl_use_coloured_output", "true"));
         return new ChallengeServerClient(hostname, journeyId, useColours);
-    }
-
-    private void showProgressAndAvailableActions(ChallengeServerClient challengeServerClient) throws UnsupportedEncodingException, UnirestException {
-        System.out.println(challengeServerClient.getJourneyProgress());
-        System.out.println(challengeServerClient.getAvailableActions());
     }
 
     private static Optional<RunnerAction> extractActionFrom(String[] args) {

--- a/src/main/java/befaster/runner/ClientRunner.java
+++ b/src/main/java/befaster/runner/ClientRunner.java
@@ -98,7 +98,7 @@ public class ClientRunner {
         String response = challengeServerClient.sendAction(line);
         System.out.println(response);
 
-        if (line.equals(START_ENDPOINT)) {
+        if (line.equals(START_ENDPOINT) || line.equals(DONE_ENDPOINT)) {
             String responseString = challengeServerClient.getRoundDescription();
             parseDescriptionFromResponse(responseString);
         }
@@ -106,11 +106,11 @@ public class ClientRunner {
 
     private void parseDescriptionFromResponse(String responseString) {
         // DEBT - the first line of the response is the ID for the round, the rest of the message is the description
-        ArrayList<String> lines = new ArrayList(Arrays.asList(responseString.split("\n")));
-        String roundId = lines.get(0);
-        lines.remove(0);
-        String description = String.join("\n", lines);
-        displayAndSaveDescription(roundId, description);
+        int newlineIndex = responseString.indexOf('\n');
+        if (newlineIndex > 0) {
+            String roundId = responseString.substring(0, newlineIndex);
+            displayAndSaveDescription(roundId, responseString);
+        }
     }
 
     private void readRunnerActionFromArgs(String[] args) {
@@ -143,8 +143,8 @@ public class ClientRunner {
 
     private ChallengeServerClient startUpAndTestChallengeServerClient() throws ConfigNotFoundException, UnsupportedEncodingException, UnirestException {
             String journeyId = readFromConfigFile("tdl_journey_id");
-            boolean disableColours = Boolean.parseBoolean(readFromConfigFile("disable_colours", "false"));
-            ChallengeServerClient challengeServerClient = new ChallengeServerClient(hostname, journeyId, disableColours);
+            boolean useColours = Boolean.parseBoolean(readFromConfigFile("tdl_use_coloured_output", "true"));
+            ChallengeServerClient challengeServerClient = new ChallengeServerClient(hostname, journeyId, useColours);
             System.out.println(challengeServerClient.getJourneyProgress());
             System.out.println(challengeServerClient.getAvailableActions());
             return challengeServerClient;

--- a/src/main/java/befaster/runner/RecordingSystem.java
+++ b/src/main/java/befaster/runner/RecordingSystem.java
@@ -9,7 +9,12 @@ import static befaster.runner.CredentialsConfigFile.readFromConfigFile;
 class RecordingSystem {
     private static final String RECORDING_SYSTEM_ENDPOINT = "http://localhost:41375";
 
-    static boolean isRunning() {
+    static boolean isRecordingSystemOk() {
+        //noinspection SimplifiableConditionalExpression
+        return RecordingSystem.isRecordingRequired() ? RecordingSystem.isRunning() : true;
+    }
+
+    private static boolean isRunning() {
         try {
             HttpResponse<String> stringHttpResponse = Unirest.get(RECORDING_SYSTEM_ENDPOINT + "/status").asString();
             if (stringHttpResponse.getStatus() == 200 && stringHttpResponse.getBody().startsWith("OK")) {
@@ -22,7 +27,7 @@ class RecordingSystem {
         return false;
     }
 
-    static boolean isRecordingRequired() {
+    private static boolean isRecordingRequired() {
         return Boolean.parseBoolean(readFromConfigFile("tdl_require_rec", "true"));
     }
 

--- a/src/main/java/befaster/runner/RecordingSystem.java
+++ b/src/main/java/befaster/runner/RecordingSystem.java
@@ -4,6 +4,8 @@ import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
 
+import static befaster.runner.CredentialsConfigFile.readFromConfigFile;
+
 class RecordingSystem {
     private static final String RECORDING_SYSTEM_ENDPOINT = "http://localhost:41375";
 
@@ -20,8 +22,16 @@ class RecordingSystem {
         return false;
     }
 
+    static boolean isRecordingRequired() {
+        return Boolean.parseBoolean(readFromConfigFile("tdl_require_rec", "true"));
+    }
+
     static void notifyEvent(String lastFetchedRound, String shortName) {
         System.out.printf("Notify round \"%s\", event \"%s\"%n", lastFetchedRound, shortName);
+
+        if (!isRecordingRequired()) {
+            return;
+        }
 
         try {
             HttpResponse<String> stringHttpResponse = Unirest.post(RECORDING_SYSTEM_ENDPOINT + "/notify")

--- a/src/main/java/befaster/runner/RoundManagement.java
+++ b/src/main/java/befaster/runner/RoundManagement.java
@@ -11,7 +11,17 @@ class RoundManagement {
     private static final Path CHALLENGES_FOLDER = Paths.get("challenges");
     private static final Path LAST_FETCHED_ROUND_PATH = CHALLENGES_FOLDER.resolve("XR.txt");
 
-    static String displayAndSaveDescription(String label, String description) {
+    static String saveDescription(String rawDescription) {
+        // DEBT - the first line of the response is the ID for the round, the rest of the responseMessage is the description
+        int newlineIndex = rawDescription.indexOf('\n');
+        if (newlineIndex > 0) {
+            String roundId = rawDescription.substring(0, newlineIndex);
+            return saveDescription(roundId, rawDescription);
+        }
+        return "OK";
+    }
+
+    static String saveDescription(String label, String description) {
         //Save description
         Path descriptionPath = CHALLENGES_FOLDER.resolve(label + ".txt");
         try {

--- a/src/main/java/befaster/runner/RoundManagement.java
+++ b/src/main/java/befaster/runner/RoundManagement.java
@@ -13,7 +13,6 @@ class RoundManagement {
 
     static String displayAndSaveDescription(String label, String description) {
         System.out.println("Starting round: " + label);
-        System.out.println(description);
 
         //Save description
         Path descriptionPath = CHALLENGES_FOLDER.resolve(label + ".txt");

--- a/src/main/java/befaster/runner/RoundManagement.java
+++ b/src/main/java/befaster/runner/RoundManagement.java
@@ -12,8 +12,6 @@ class RoundManagement {
     private static final Path LAST_FETCHED_ROUND_PATH = CHALLENGES_FOLDER.resolve("XR.txt");
 
     static String displayAndSaveDescription(String label, String description) {
-        System.out.println("Starting round: " + label);
-
         //Save description
         Path descriptionPath = CHALLENGES_FOLDER.resolve(label + ".txt");
         try {


### PR DESCRIPTION
JavaD2. Allow the server commands to be read from stdin, like the way the console-ui works but without the loop
JavaD3. Allow the runner commands (getNewRoundDescription, testConnectivity, deployToProduction) to be read from the stdin but maintain the ability to pass commands as args to the process
JavaD4. Bind server commands to runner commands: