### PR TITLE
Adding instructions for Gradle and Maven into the README of the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
-# tdl-warmup-java
+# tdl-runner-java
 
 
 ## 1. Requirements
 
 - `Java 1.8`
 
-## 2. How to start
+## 2. Import project
+
+You can import this project either via Maven (`pom.xml`) or Gradle (`build.gradle`) into your IDE (if either of these are supported by your IDE).
+
+## 3. How to start
 
 - Open `src/main/java/befaster/SendCommandToServer.java`
 - Read the comments as documentation, they will guide through the rest of the setup

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 Importing an existing Maven project into IntelliJ
 - Open IntelliJ IDEA and close any existing project
 - From the Welcome screen, click Import Project...
-- Navigate to your Maven project  (`pom.xml` file) and select the top-level folder...
+- Navigate to your Maven project (`pom.xml` file) and select the top-level folder...
 - Click OK...
 
 See [How to import post from JetBrains](https://blog.jetbrains.com/idea/2008/03/opening-maven-projects-is-easy-as-pie/)
@@ -34,7 +34,7 @@ See also [Importing a project from a Gradle model](https://www.jetbrains.com/hel
 
 ### Other IDEs
 
- 
+You have to import and run the respective Maven project (`pom.xml` file) and Gradle project (`build.gradle` file) files into your IDE, depending on the support for these types of build files. 
 
 ## 3. How to start
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,34 @@
 
 ## 2. Import project
 
-You can import this project either via Maven (`pom.xml`) or Gradle (`build.gradle`) into your IDE (if either of these are supported by your IDE).
+### Eclipse
+
+
+### IntelliJ
+
+#### Maven project
+
+Importing an existing Maven project into IntelliJ
+- Open IntelliJ IDEA and close any existing project
+- From the Welcome screen, click Import Project...
+- Navigate to your Maven project  (`pom.xml` file) and select the top-level folder...
+- Click OK...
+
+See [How to import post from JetBrains](https://blog.jetbrains.com/idea/2008/03/opening-maven-projects-is-easy-as-pie/)
+
+#### Gradle project
+
+Importing an existing Gradle project into IntelliJ
+- Open IntelliJ IDEA and close any existing project
+- From the Welcome screen, click Import Project...
+- Navigate to your Gradle project (`build.gradle` file) and select the top-level folder...
+- Click OK...
+
+See also [Importing a project from a Gradle model](https://www.jetbrains.com/help/idea/gradle.html#gradle_import)
+
+### Other IDEs
+
+ 
 
 ## 3. How to start
 


### PR DESCRIPTION
The current README does not have any import instructions.